### PR TITLE
Use "in early 2018" instead of "in the early 2018"

### DIFF
--- a/docs/index.js
+++ b/docs/index.js
@@ -229,9 +229,9 @@ const SECTIONS = [
           feature of VimFx – link hinting.
         </p>
         <p>
-          During experimentation in the early 2018, I discovered a way of
-          keeping track of clickable elements in the background (for the
-          technically interested, a combination of{" "}
+          During experimentation in early 2018, I discovered a way of keeping
+          track of clickable elements in the background (for the technically
+          interested, a combination of{" "}
           <a href="https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver">
             MutationObserver
           </a>


### PR DESCRIPTION
I think this is more correct/idiomatic.