### PR TITLE
Always mark links as clickable when selecting

### DIFF
--- a/src/worker/ElementManager.js
+++ b/src/worker/ElementManager.js
@@ -1438,8 +1438,6 @@ export default class ElementManager {
     }
 
     switch (element.nodeName) {
-      case "A":
-        return element instanceof HTMLAnchorElement ? "clickable" : undefined;
       // Always consider the following elements as selectable, regardless of their
       // children, since they have special context menu items. A
       // `<canvas><p>fallback</p></canvas>` could be considered a wrapper element
@@ -1448,6 +1446,7 @@ export default class ElementManager {
       // give frames hints during regular click hints mode for that reason, but
       // unfortunately for example Twitter uses iframes for many of its little
       // widgets/embeds which would result in many unnecessary/confusing hints.
+      case "A":
       case "AUDIO":
       case "BUTTON":
       case "SELECT":

--- a/src/worker/ElementManager.js
+++ b/src/worker/ElementManager.js
@@ -1438,13 +1438,8 @@ export default class ElementManager {
     }
 
     switch (element.nodeName) {
-      // Links _could_ be marked as "clickable" as well for simplicity, but
-      // marking them as "link" allows opening them in a new tab by holding alt
-      // for consistency with all other hints modes.
       case "A":
-        return element instanceof HTMLAnchorElement
-          ? getLinkElementType(element)
-          : undefined;
+        return element instanceof HTMLAnchorElement ? "clickable" : undefined;
       // Always consider the following elements as selectable, regardless of their
       // children, since they have special context menu items. A
       // `<canvas><p>fallback</p></canvas>` could be considered a wrapper element


### PR DESCRIPTION
Since they can no longer be opened in a new tab by holding <kbd>Alt</kbd>.
