### PR TITLE
Fix link in popup only working properly in Firefox

### DIFF
--- a/src/popup/Program.tsx
+++ b/src/popup/Program.tsx
@@ -95,7 +95,9 @@ export default class PopupProgram {
           </h1>
 
           <p>
-            <a href={META_HOMEPAGE} target="_blank">Homepage</a>
+            <a href={META_HOMEPAGE} target="_blank" rel="noreferrer">
+              Homepage
+            </a>
           </p>
         </div>
 

--- a/src/popup/Program.tsx
+++ b/src/popup/Program.tsx
@@ -95,7 +95,7 @@ export default class PopupProgram {
           </h1>
 
           <p>
-            <a href={META_HOMEPAGE}>Homepage</a>
+            <a href={META_HOMEPAGE} target="_blank">Homepage</a>
           </p>
         </div>
 


### PR DESCRIPTION
I am using Vivaldi as my main browser and when clicking the homepage link in the popup, it opens the homepage in the actual popup. (if i middle click the link it opens in a normal tab).

I tested the same thing in firefox, where it worked fine. But in chromium, nothing happened.

So this PR adds `target="_blank"` to the link tag and now it works as expected (opens webpage in a new normal tab) in all three browsers.

---

A suggestion: add a link to the tutorial in the popup as well.

btw, I use Arch
<!--
Thank you for contributing to Link Hints!

Before submitting, it’s nice to:

- Check that `npm test` runs successfully.
- Test in both Firefox and Chrome.
-->
