### PR TITLE
Add hidden option for preferring windows over tabs

### DIFF
--- a/src/options/Tweakable.tsx
+++ b/src/options/Tweakable.tsx
@@ -142,6 +142,29 @@ function TweakableField({
   };
 
   switch (value.type) {
+    case "Bool":
+      if (defaultValue.type === "Bool") {
+        return (
+          <Field
+            {...fieldProps}
+            render={({ id }) => (
+              <label className="Spaced Spaced--center">
+                <input
+                  type="checkbox"
+                  id={id}
+                  checked={value.value}
+                  onChange={(event) => {
+                    save(fullKey, event.currentTarget.checked);
+                  }}
+                />
+                <span>Enabled</span>
+              </label>
+            )}
+          />
+        );
+      }
+      break;
+
     case "UnsignedInt":
       if (defaultValue.type === "UnsignedInt") {
         return (

--- a/src/shared/tweakable.ts
+++ b/src/shared/tweakable.ts
@@ -1,4 +1,11 @@
-import { array, chain, Decoder, DecoderError, string } from "tiny-decoders";
+import {
+  array,
+  boolean,
+  chain,
+  Decoder,
+  DecoderError,
+  string,
+} from "tiny-decoders";
 
 import { ElementType } from "./hints";
 import {
@@ -10,6 +17,11 @@ import {
   UnsignedInt,
 } from "./main";
 import { DEBUG_PREFIX } from "./options";
+
+type Bool = {
+  type: "Bool";
+  value: boolean;
+};
 
 type UnsignedInt = {
   type: "UnsignedInt";
@@ -42,6 +54,7 @@ type Regex = {
 };
 
 export type TweakableValue =
+  | Bool
   | ElementTypeSet
   | Regex
   | SelectorString
@@ -59,6 +72,13 @@ export type TweakableMeta = {
   loaded: Promise<void>;
   unlisten: () => void;
 };
+
+export function bool(value: boolean): Bool {
+  return {
+    type: "Bool",
+    value,
+  };
+}
 
 export function unsignedInt(value: number): UnsignedInt {
   return {
@@ -132,6 +152,16 @@ export function tweakable(
         }
 
         switch (original.type) {
+          case "Bool": {
+            const decoded = decode(boolean, value);
+            mapping[key] = {
+              type: "Bool",
+              value: decoded,
+            };
+            changed[key] = decoded !== original.value;
+            break;
+          }
+
           case "UnsignedInt": {
             const decoded = decode(UnsignedInt, value);
             mapping[key] = {


### PR DESCRIPTION
Addresses #54.

In short:

- `Alt+K` and `Alt+Shift+K` opens links in new background _windows_ instead of tabs. Note: Firefox seems to _always_ focus new windows currently, while Chrome is able to open windows in the background. So on Firefox, Alt+K and Alt+L are effectively the same, and Alt+Shift+K just feels broken when you use it.
- `Alt+L` opens links in new foreground _windows_ instead of tabs.
- Holding `Alt` while activating a hint opens the link in a new _window_ instead of tab.

This is kept as a hidden option since it doesn’t work 100 %. I’ll revisit again as more users of this feature show up.