### PR TITLE
Fix "can't access dead object" crashes from sandboxed iframes in Firefox

### DIFF
--- a/html/sandboxed-iframe/index.html
+++ b/html/sandboxed-iframe/index.html
@@ -1,0 +1,164 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Sandboxed iframe</title>
+    <style>
+      #status {
+        font-weight: bold;
+      }
+
+      #status.ok {
+        color: green;
+      }
+
+      #status.fail {
+        color: red;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Sandboxed iframe (the Proton Mail pattern)</h1>
+
+    <p>
+      This replicates what broke Proton Mail in Firefox (<a
+        href="https://github.com/lydell/LinkHints/issues/99"
+        >issue #99</a
+      >): The “email” is rendered into a sandboxed
+      <code>about:blank</code> iframe <em>without</em>
+      <code>allow-scripts</code>. Listeners are attached to the iframe’s
+      <code>body</code> (like Proton’s <code>useIframeDispatchEvents</code>).
+      “Switching email” removes the iframe from the DOM, and a
+      <em>deferred</em> cleanup (like React’s passive effect cleanup) calls
+      <code>removeEventListener</code> on the old <code>body</code>.
+    </p>
+
+    <p>
+      With the bug present, the cleanup throws
+      <code>TypeError: can't access dead object</code> in Firefox, because the
+      hooked <code>removeEventListener</code> died together with the removed
+      frame’s content script sandbox.
+    </p>
+
+    <p>
+      <button id="switch" type="button">Switch email</button>
+      <button id="auto" type="button">Switch 10 times</button>
+      <span id="status"></span>
+    </p>
+
+    <div id="root"></div>
+
+    <pre id="log"></pre>
+
+    <script>
+      "use strict";
+
+      // Same list as Proton’s useIframeDispatchEvents.
+      const EVENTS = ["focus", "keydown", "click", "copy", "dragstart"];
+
+      const root = document.getElementById("root");
+      const logElement = document.getElementById("log");
+      const statusElement = document.getElementById("status");
+
+      let current = undefined;
+      let counter = 0;
+      let numErrors = 0;
+      let numCleanups = 0;
+
+      function log(message) {
+        logElement.textContent += `${message}\n`;
+      }
+
+      function updateStatus() {
+        if (numErrors === 0) {
+          statusElement.textContent =
+            numCleanups === 0 ? "" : `OK (${numCleanups} cleanups)`;
+          statusElement.className = "ok";
+        } else {
+          statusElement.textContent = `FAIL (${numErrors}/${numCleanups} cleanups threw)`;
+          statusElement.className = "fail";
+        }
+      }
+
+      function writeEmail(doc, text) {
+        doc.open();
+        doc.write(
+          '<!DOCTYPE html><html><body style="margin: 0; border: 1px solid #ccc;">' +
+            `<p>Email ${text}</p><a href="#link">A link</a>` +
+            "</body></html>"
+        );
+        doc.close();
+      }
+
+      // React schedules passive effects (and their cleanups) in a macrotask
+      // after the commit, via a MessageChannel.
+      function scheduleCleanup(fn) {
+        const channel = new MessageChannel();
+        channel.port1.onmessage = fn;
+        channel.port2.postMessage(null);
+      }
+
+      function switchEmail() {
+        counter += 1;
+
+        // Mount the new “email”.
+        const iframe = document.createElement("iframe");
+        iframe.src = "about:blank";
+        iframe.setAttribute(
+          "sandbox",
+          "allow-same-origin allow-popups allow-popups-to-escape-sandbox"
+        );
+        root.textContent = "";
+        root.append(iframe);
+        writeEmail(iframe.contentDocument, counter);
+
+        // “useEffect”: capture the body and attach listeners.
+        const body = iframe.contentWindow.document.body;
+        const callback = () => {};
+        for (const type of EVENTS) {
+          body.addEventListener(type, callback);
+        }
+
+        const previous = current;
+        current = { iframe, body, callback };
+
+        if (previous !== undefined) {
+          // “Commit phase”: the remount removes the old iframe from the DOM.
+          previous.iframe.remove();
+
+          // “Deferred passive effect cleanup”.
+          scheduleCleanup(() => {
+            numCleanups += 1;
+            try {
+              for (const type of EVENTS) {
+                previous.body.removeEventListener(type, previous.callback);
+              }
+              log(`cleanup after email ${counter}: ok`);
+            } catch (error) {
+              numErrors += 1;
+              log(
+                `cleanup after email ${counter}: ${error.name}: ${error.message}`
+              );
+            }
+            updateStatus();
+          });
+        }
+
+        updateStatus();
+      }
+
+      document
+        .getElementById("switch")
+        .addEventListener("click", () => switchEmail());
+
+      document.getElementById("auto").addEventListener("click", async () => {
+        for (let index = 0; index < 10; index++) {
+          switchEmail();
+          await new Promise((resolve) => setTimeout(resolve, 50));
+        }
+      });
+
+      switchEmail();
+    </script>
+  </body>
+</html>

--- a/src/worker/ElementManager.ts
+++ b/src/worker/ElementManager.ts
@@ -414,6 +414,20 @@ export default class ElementManager {
     }
 
     if (BROWSER === "firefox") {
+      // Skip sandboxed iframes without `allow-scripts`. No page scripts can
+      // run in them, so there is nothing for the injected script to detect.
+      // (In Chrome, the below script element simply doesn’t run in such
+      // frames.) More importantly, this avoids breaking the parent page:
+      // `injected()` replaces page prototype methods with `exportFunction`:s
+      // tied to this frame’s content script sandbox, which is nuked if the
+      // frame is removed from the DOM. If the parent page kept references to
+      // the frame’s objects and calls such a method afterwards (like React
+      // effect cleanups calling `.removeEventListener()`), it gets
+      // "TypeError: can't access dead object".
+      // <https://github.com/lydell/LinkHints/issues/99>
+      if (!canRunPageScripts()) {
+        return;
+      }
       injected(this);
       return;
     }
@@ -2167,6 +2181,22 @@ function isWithin(point: Point, box: Box): boolean {
     // Use `<`, not `<=`, since a point at `box.y + box.height` is located at
     // the first pixel _below_ the box.
     point.y < box.y + box.height
+  );
+}
+
+// Whether page scripts can run in this frame. They can’t in sandboxed
+// iframes without the `allow-scripts` keyword. (Content scripts still run in
+// such iframes.) `window.frameElement` is only accessible when the frame and
+// its parent are same-origin, but that’s also the only case where the parent
+// can touch the frame’s objects (and thus be affected by dead hooks).
+function canRunPageScripts(): boolean {
+  const { frameElement } = window;
+  if (frameElement === null || !("sandbox" in frameElement)) {
+    return true;
+  }
+  const iframe = frameElement as HTMLIFrameElement;
+  return (
+    !iframe.hasAttribute("sandbox") || iframe.sandbox.contains("allow-scripts")
   );
 }
 


### PR DESCRIPTION
Fixes #99.

## Root cause

In Firefox, `injected.ts` runs in the content script sandbox and replaces page prototype methods (`EventTarget.prototype.addEventListener`/`removeEventListener`, `Document.prototype.open`/`write`, `Element.prototype.attachShadow`, `onclick` setters) with `exportFunction`:s tied to the frame's content script sandbox.

When a frame is removed from the DOM, Firefox nukes that sandbox — silently, without any lifecycle event reaching the content script (verified: no `pagehide`/`unload` fires on iframe removal). The exported functions left behind on the frame's old prototypes become dead wrappers. If the page kept references to the frame's objects and later calls one of those methods, it gets `TypeError: can't access dead object`.

Proton Mail hits exactly this: it renders emails into a sandboxed `about:blank` iframe **without `allow-scripts`** (`sandbox="allow-same-origin allow-popups allow-popups-to-escape-sandbox"`). When switching emails, React removes the iframe, and its deferred effect cleanups (`useIframeDispatchEvents.ts`, `useLinkHandler.tsx`) then call `removeEventListener` on the old iframe's body → dead wrapper call → ErrorBoundary → "Something went wrong".

## Reproduction

I reproduced the crash with a minimal page replicating Proton's pattern (sandboxed `about:blank` iframe, `document.open/write/close`, listeners on the body, iframe removed, deferred `removeEventListener` cleanup), driven automatically in Firefox via geckodriver:

| | unmount (iframe removed) | document.open/write reuse |
| --- | --- | --- |
| no extension | no errors | no errors |
| LinkHints 1.3.3 | **`TypeError: can't access dead object`** in every cleanup | no errors |
| LinkHints + this patch | no errors | no errors |

Also verified that no `pagehide`/`unload`/`beforeunload` events reach the content script of a removed iframe, so restoring the hooks on teardown is not possible.

## Fix

Skip `injected()` in sandboxed iframes without `allow-scripts`. No page scripts can run in such frames, so there is nothing for the injected script to detect. In Chrome, the injected `<script>` element doesn't run in such frames anyway, so this aligns Firefox behavior with Chrome.

`window.frameElement` is only accessible when the frame and its parent are same-origin — but that's also the only case where the parent can access the frame's objects at all, and thus the only case where dead hooks can be triggered.

## Limitations

Same-origin iframes sandboxed *with* `allow-scripts` still get the hooks (they need them), so the same crash is theoretically possible there. A complete fix would require a Firefox platform change (a teardown signal for content scripts).
