### PR TITLE
Fix exception in Firefox when iframes are deleted

### DIFF
--- a/@types/globals.d.ts
+++ b/@types/globals.d.ts
@@ -76,6 +76,11 @@ declare namespace browser.tabs {
   }
 }
 
+// This was missing in `@types/firefox-webext-browser` at the time of writing.
+declare namespace browser.runtime {
+  export function getDocumentId(target: Window): string;
+}
+
 interface ShadowRoot {
   elementFromPoint: Document["elementFromPoint"];
   elementsFromPoint: Document["elementsFromPoint"];

--- a/html/frames/removed/index.html
+++ b/html/frames/removed/index.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Removed iframe</title>
+  </head>
+  <body>
+    <h1>Removed iframe</h1>
+
+    <p>
+      Click the button to replace the iframe with a new one. The parent page
+      holds a reference to the body of the iframe, and tries to add event
+      listeners to the removed iframe after it was replaced. That is useless,
+      but used to cause an <code>TypeError: can't access dead object</code> in
+      Firefox. This broke Proton Mail.
+    </p>
+
+    <p>
+      <button onclick="switchIframe()">Replace iframe</button>
+      <strong id="result"></strong>
+    </p>
+
+    <div id="root"></div>
+
+    <pre id="log"></pre>
+
+    <script>
+      let current = undefined;
+      let counter = 0;
+
+      function writeIframe(doc, text) {
+        doc.open();
+        doc.write(
+          `
+            <!DOCTYPE html>
+            <html>
+              <body>
+                <p>Generation ${text}</p>
+                <p><a href="#link">A link</a>, an <strong id="click1">element with a click listener</strong> and an <strong id="click2">element with onclick</strong>.</p>
+                <script>
+                  click1.addEventListener("click", () => {
+                    click1.style.color = "green";
+                  });
+                  click2.onclick = () => {
+                    click2.style.color = "green";
+                  };
+                <\/script>
+              </body>
+            </html>
+          `
+        );
+        doc.close();
+      }
+
+      function switchIframe() {
+        counter += 1;
+
+        const iframe = document.createElement("iframe");
+        iframe.src = "about:blank";
+        root.replaceChildren(iframe);
+        writeIframe(iframe.contentDocument, counter);
+
+        const previous = current;
+        current = iframe.contentWindow.document.body;
+
+        if (previous !== undefined) {
+          // Things don’t fail if done synchronously after the iframe got removed.
+          setTimeout(() => {
+            try {
+              // Doing stuff like this to elements inside an already removed iframe
+              // is useless, but should not throw errors.
+              previous.addEventListener("focus", () => {});
+              previous.onclick = () => {};
+              result.textContent = "OK";
+              result.style.color = "green";
+            } catch (error) {
+              result.textContent = "FAIL";
+              result.style.color = "red";
+              log.textContent += `${error.name}: ${error.message}\n${error.stack}`;
+            }
+          }, 0);
+        }
+      }
+
+      switchIframe();
+    </script>
+  </body>
+</html>

--- a/src/worker/injected.ts
+++ b/src/worker/injected.ts
@@ -39,11 +39,16 @@ export const CLICKABLE_EVENT_PROPS: Array<string> = CLICKABLE_EVENT_NAMES.map(
 // malicious sites to send these events. Luckily, that doesn’t hurt much. All
 // the page could do is cause false positives or disable detection of click
 // events altogether.
-const prefix = `__${META_SLUG}WebExt_${BUILD_ID}_`;
+// Also used to define `window[iframeWrapName]`. In that case we want the
+// defined name to get lost among all the other stuff on `window`. Lots of
+// things start with `Web`, such as `WebGL` (lots of constructors), `WebTransport`,
+// and `WebSocket`. Having the name start with underscores is bad, since they
+// sort first.
+const prefix = `WebExt_${META_SLUG}_${BUILD_ID}_`;
 
 // Events that don’t need to think about the iframe edge case described above
 // can use this more secure prefix, with a practically unguessable part in it.
-const secretPrefix = `__${META_SLUG}WebExt_${makeRandomToken()}_`;
+const secretPrefix = `WebExt_${META_SLUG}_${makeRandomToken()}_`;
 
 export const CLICKABLE_CHANGED_EVENT = `${prefix}ClickableChanged`;
 export const OPEN_SHADOW_ROOT_CREATED_EVENT = `${prefix}OpenShadowRootCreated`;
@@ -69,6 +74,13 @@ export type FromInjected =
   | { type: "Queue"; hasQueue: boolean }
   | { type: "ShadowRootCreated"; shadowRoot: ShadowRoot };
 
+type IframeWrap = ((
+  fn: (...args: Array<never>) => unknown,
+  originalFn: (...args: Array<never>) => unknown
+) => (this: unknown, ...args: Array<unknown>) => unknown) & {
+  documentId: string;
+};
+
 export default (communicator?: {
   onInjectedMessage: (message: FromInjected) => unknown;
   addEventListener: (
@@ -79,6 +91,53 @@ export default (communicator?: {
 }): void => {
   // Refers to the page `window` both in Firefox and other browsers.
   const win = BROWSER === "firefox" ? window.wrappedJSObject ?? window : window;
+
+  const iframeWrapName = `${prefix}A`;
+
+  const getDocumentId = (target: Window): string => {
+    // This API was added in Firefox 153. At the time of writing, that was too
+    // recent to require as the minimum version. The document ID is used as
+    // an extra precaution against the web page having overridden the
+    // `window[iframeWrapName]` function (despite it being non-configurable),
+    // so it is not essential.
+    // The code is written slightly weirdly to avoid `web-ext lint` reporting
+    // this API as unsupported.
+    const name = "getDocumentId";
+    const api = browser.runtime[name];
+    return typeof api === "function" ? api(target) : "";
+  };
+
+  if (BROWSER === "firefox") {
+    // If an iframe is removed from the DOM, scripts running in it are immediately
+    // killed. If the parent page has a reference to the iframe document, it can
+    // still try to call stuff in it, like `.removeEventListener`. Firefox then
+    // fails with `TypeError: can't access dead object`, since `.removeEventListener`
+    // is overridden using `exportFunction`. The only way I’ve found to get around
+    // this is to define a function in the _parent_ to the iframe, and use that
+    // function in the iframe. Then `.removeEventListener` will be set to a function
+    // defined in the parent, which survives when the iframe is removed, and has a
+    // chance to catch the “dead object” error. Unfortunately, this function _has_
+    // to be exposed on the `window` that can be seen by the web page (`win`).
+    // Defining it on the `window` only seen by the extension still results in the
+    // “dead object” error. Note that we don’t use `exportFunction` here, so the
+    // web page can only see the property (for example in the browser console,
+    // but it is not enumerable with for example `Object.keys`), but they cannot
+    // call it (that results in an exception).
+    const iframeWrap: IframeWrap = (fn, originalFn) =>
+      function (this: unknown, ...args): unknown {
+        try {
+          return apply(fn, this, args);
+        } catch {
+          return apply(originalFn, this, args);
+        }
+      };
+    // The property is non-configurable, but as an extra precaution, add this UUID
+    // to the function, which is very difficult for the page to guess.
+    iframeWrap.documentId = getDocumentId(window);
+    Reflect.defineProperty(win, iframeWrapName, {
+      value: iframeWrap,
+    });
+  }
 
   // These arrays are replaced in by ElementManager; only refer to them once.
   const clickableEventNames = CLICKABLE_EVENT_NAMES;
@@ -266,8 +325,34 @@ export default (communicator?: {
       let newDescriptor = { ...descriptor, [prop]: fn };
 
       if (BROWSER === "firefox") {
+        let wrappedFn = fn;
+        if (window.parent !== window) {
+          let iframeWrap: IframeWrap | undefined = undefined;
+          try {
+            iframeWrap = win.parent[
+              iframeWrapName as unknown as number
+            ] as unknown as IframeWrap;
+          } catch {
+            // Accessing stuff on the parent throws an error if we’re in an iframe
+            // that is on a different origin than the parent. There is no way
+            // checking for this, so try-catch and ignore errors is the way to go.
+          }
+          if (
+            typeof iframeWrap === "function" &&
+            iframeWrap.documentId === getDocumentId(window.parent)
+          ) {
+            const returnValue = iframeWrap(
+              exportFunction(fn, new win.Object(), { defineAs: name }),
+              originalFn
+            );
+            if (typeof returnValue === "function") {
+              wrappedFn = returnValue;
+            }
+          }
+        }
+
         if (prop === "value") {
-          exportFunction(fn, obj, { defineAs: name });
+          exportFunction(wrappedFn, obj, { defineAs: name });
           setLength(obj[name]);
           this.resetFns.push(() => {
             exportFunction(originalFn, obj, { defineAs: name });
@@ -276,7 +361,7 @@ export default (communicator?: {
         }
 
         newDescriptor = Object.assign(new win.Object(), descriptor, {
-          set: exportFunction(fn, new win.Object(), { defineAs: name }),
+          set: exportFunction(wrappedFn, new win.Object(), { defineAs: name }),
         });
       }
 


### PR DESCRIPTION
A page can:

1. Hold a reference to elements in an iframe (if the origin is the same).
2. Remove the iframe from the page.
3. Add or remove event listeners to elements in the iframe.

This previously caused an exception in Firefox:

> TypeError: can't access dead object

This PR adds a workaround for this situation.

Fixes #99 (Proton Mail broken).

Supersedes #117. That PR tried to fix it by avoiding injections in sandboxed iframes that don’t allow JavaScript, which fixes Proton Mail, but does not fix the issue in general. The problem has nothing to to with sandboxing, it’s just that Proton Mail happens to do that.
